### PR TITLE
Update documentation to reflect behavior of reference implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Dot -> Empty -> Dot -> Dot -> Dollar
 | --- | --- | --- |
 | ![empty](examples/symbols/empty.jpg) | `Empty` | Writes a binary 0 |
 | ![dot](examples/symbols/dot.jpg) | `Dot` | Writes a binary 1 |
-| ![dollar](examples/symbols/dollar.jpg) | `Dollar` | Terminates const loading |
+| ![dollar](examples/symbols/dollar.jpg) | `Dollar` | Terminates const loading and pushes result onto stack or duplicates topmost stack element |
 
 ### Arithmetic
 


### PR DESCRIPTION
As per the reference interpreter implementation:

https://github.com/hgarrereyn/OCRaaP/blob/321df0d2a6e789930ca03a57a56d9d3efe9d1d70/interpreter.py#L264-L274

The 'dollar' instruction will duplicate the topmost stack element if there is no constant being loaded.

This pull request updates the instruction set architecture specification document (`README.md`) to reflect the behavior of the reference implementation of this instruction.